### PR TITLE
Fix README reference for Docker demo

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@
 - Optional temporary replication slot may be created for `pg_receivewal` (`--slot` flag)
 - **Parallel database sync via rsync+rsyncd**
 - Streaming WAL with `pg_receivewal`
-- Automated testing/demo via Docker (`docker-test.sh`)
+- Automated testing/demo via Docker (`demo.sh`)
 - Debug-friendly flags: `--debug` (shell trace) and `--keep-run-tmp` (preserve temp files)
 - Can wipe an existing replica directory with `--drop-existing`
 


### PR DESCRIPTION
## Summary
- correct outdated script name in README

## Testing
- `run-tests.sh` *(fails: bats_support missing and docker not installed)*

------
https://chatgpt.com/codex/tasks/task_e_686d2cad56148323895504b4674e9fed