### PR TITLE
Fix network_rm condition

### DIFF
--- a/tests/common.sh
+++ b/tests/common.sh
@@ -23,7 +23,7 @@ network_up() {
 }
 
 network_rm() {
-  docker network inspect "$NETWORK" &>/dev/null || docker network rm "$NETWORK"
+  docker network inspect "$NETWORK" &>/dev/null && docker network rm "$NETWORK"
 }
 
 start_primary() {


### PR DESCRIPTION
## Summary
- ensure docker network removal runs after inspect
- run shellcheck on tests/common.sh

## Testing
- `shellcheck tests/common.sh`
- `./run-tests.sh` *(fails: docker: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686d2c9e37c883238e8c26abaa45a0cc