### PR TITLE
Add watchdog abort tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,8 @@ tests/test_helper/*
 .bats-tmp/
 *.log
 *.tmp
+# cursor files
+.cursor/
+# claude files
+CLAUDE.md
+.mcp.json

--- a/pgclone
+++ b/pgclone
@@ -5,7 +5,7 @@
 
 set -euo pipefail
 
-PGCLONE_VERSION="1.0.1"
+PGCLONE_VERSION="1.1.0"
 
 # ==== Default parameters ====
 PGPORT=5432                 # TCP port of the primary Postgres instance (default 5432)
@@ -52,6 +52,8 @@ RSYNCD_WATCHDOG_PID=""
 PSQL_WATCHDOG_PID=""
 RSYNC_LOGFILES=()
 RUN_TMPDIR=""
+PIDFILE=""
+PGCLONE_MAIN_PID=""
 
 # ==== Logging ====
 log() { [[ "$VERBOSE" == "1" ]] && echo "[$(date '+%F %T')] [pgclone] $*" >&2; return 0; }
@@ -62,9 +64,25 @@ fatal() { err "$@"; exit 1; }
 # shellcheck disable=SC2317
 cleanup() {
     rc=$?
+    reason="$1"
+
     [[ "$CLEANUP_DONE" == "1" ]] && exit "$rc"
     CLEANUP_DONE=1
+
+    if [[ "$reason" != "EXIT" ]]; then
+        if [[ "$rc" == "0" ]]; then
+            rc=1
+        fi
+        log "$reason received, cleaning up and exiting with rc=$rc"
+    fi
+
     log "Running cleanup (rc=$rc)..."
+
+    # Stop pg_receivewal watchdog
+    if [[ -n "${PG_RECEIVEWAL_WATCHDOG_PID:-}" ]]; then
+        kill "$PG_RECEIVEWAL_WATCHDOG_PID" 2>/dev/null || true
+        wait_and_kill_process "$PG_RECEIVEWAL_WATCHDOG_PID" "pg_receivewal watchdog"
+    fi
 
     # Stop pg_receivewal
     if [[ -n "${PG_RECEIVEWAL_PID:-}" ]]; then
@@ -73,11 +91,6 @@ cleanup() {
         wait_and_kill_process "$PG_RECEIVEWAL_PID" "pg_receivewal"
     fi
 
-    # Stop pg_receivewal watchdog
-    if [[ -n "${PG_RECEIVEWAL_WATCHDOG_PID:-}" ]]; then
-        kill "$PG_RECEIVEWAL_WATCHDOG_PID" 2>/dev/null || true
-        wait_and_kill_process "$PG_RECEIVEWAL_WATCHDOG_PID" "pg_receivewal watchdog"
-    fi
     # Stop rsyncd on master via ssh PID
     if [[ -n "${RSYNCD_SSH_PID:-}" ]]; then
         log "Stopping rsyncd (via SSH PID=$RSYNCD_SSH_PID)..."
@@ -148,7 +161,12 @@ cleanup() {
     log "Cleanup complete (rc=$rc)"
     exit "$rc"
 }
-trap cleanup EXIT INT TERM ERR
+
+trap 'cleanup EXIT' EXIT
+trap 'cleanup TERM' TERM
+trap 'cleanup INT' INT
+trap 'cleanup ERR' ERR
+
 
 # ==== Helpers ====
 
@@ -531,6 +549,10 @@ fi
 # All per-run temporary files/subdirs are created under this directory to simplify cleanup.
 RUN_TMPDIR=$(mktemp -d -t pgclone_.XXXXXX)
 log "Using run temp directory $RUN_TMPDIR"
+PIDFILE="$RUN_TMPDIR/pgclone.pid"
+PGCLONE_MAIN_PID="$$"
+echo $PGCLONE_MAIN_PID > "$PIDFILE"
+
 
 # ==== Validate ====
 : "${PGHOST:?--pghost required}"
@@ -648,15 +670,21 @@ exec 3>"$PSQL_IN"
 psql_send() { echo "$1" >&3; }
 psql_wait() { grep -m 1 . <"$PSQL_OUT"; }
 
-# Watchdog: terminate main script if psql session exits
+# Watchdog: terminate main script if psql session exits,
+#           terminate psql if main script dies.
 (
     child_pid=$PSQL_PID
-    main_pid=$PPID
+    main_pid=$PGCLONE_MAIN_PID
     while kill -0 "$child_pid" 2>/dev/null && kill -0 "$main_pid" 2>/dev/null; do
         sleep 1
     done
-    kill -0 "$main_pid" 2>/dev/null || exit 0
-    log "[watchdog] psql session PID=$child_pid exited"
+    if ! kill -0 "$main_pid" 2>/dev/null; then
+        log "[psql_watchdog] Main process $main_pid died -> terminating psql PID=$child_pid"
+        watchdog_terminate "$child_pid" "psql"
+        exit 0
+    fi
+    log "[psql_watchdog] psql session PID=$child_pid exited"
+    log "[psql_watchdog] Terminating main process $main_pid"
     kill -TERM "$main_pid" 2>/dev/null
 ) &
 PSQL_WATCHDOG_PID=$!
@@ -705,17 +733,18 @@ fi
 
 # ==== Watchdog for pg_receivewal ====
 (
-    child_pid=$PG_RECEIVEWAL_PID       # pid of pg_receivewal
-    main_pid=$PPID                     # pid of the main script
+    child_pid=$PG_RECEIVEWAL_PID
+    main_pid=$PGCLONE_MAIN_PID
     while kill -0 "$child_pid" 2>/dev/null && kill -0 "$main_pid" 2>/dev/null; do
         sleep 1
     done
     if ! kill -0 "$main_pid" 2>/dev/null; then
-        log "[watchdog] Main process $main_pid died -> terminating pg_receivewal PID=$child_pid"
+        log "[pg_receivewal_watchdog] Main process $main_pid died -> terminating pg_receivewal PID=$child_pid"
         watchdog_terminate "$child_pid" "pg_receivewal"
         exit 0
     fi
-    log "[watchdog] pg_receivewal PID=$child_pid exited"
+    log "[pg_receivewal_watchdog] pg_receivewal PID=$child_pid exited"
+    log "[pg_receivewal_watchdog] Terminating main process $main_pid"
     kill -TERM "$main_pid" 2>/dev/null
 ) &
 PG_RECEIVEWAL_WATCHDOG_PID=$!
@@ -829,7 +858,7 @@ RSYNCD_SSH_PID=$!
     while kill -0 "$main_pid" 2>/dev/null; do
         sleep 1
     done
-    log "[watchdog] Main process $main_pid died -> terminating rsyncd-ssh PID=$RSYNCD_SSH_PID"
+    log "[rsyncd_watchdog] Main process $main_pid died -> terminating rsyncd-ssh PID=$RSYNCD_SSH_PID"
     watchdog_terminate "$RSYNCD_SSH_PID" "rsyncd ssh session"
 ) &
 RSYNCD_WATCHDOG_PID=$!
@@ -941,11 +970,13 @@ ssh_exec "cat $(shquote "$PRIMARY_PGDATA")/global/pg_control" \
 log "Backup stopped at LSN $STOP_LSN and control files written"
 
 log "Closing persistent psql session..."
-psql_send '\q'
-wait_and_kill_process "$PSQL_PID" "persistent psql session"
+# Terminate psql watchdog first, because it may be waiting for psql session to exit.
 kill -TERM "$PSQL_WATCHDOG_PID" 2>/dev/null || true
 wait_and_kill_process "$PSQL_WATCHDOG_PID" "psql watchdog"
 PSQL_WATCHDOG_PID=""
+# Then terminate psql session
+psql_send '\q'
+wait_and_kill_process "$PSQL_PID" "persistent psql session"
 
 # We must be certain the WAL segment that contains STOP_LSN is present on the replica
 # *before* we stop pg_receivewal.  Otherwise the standby will ask for that segment
@@ -974,10 +1005,12 @@ log "WAL $STOP_WALFILE received"
 # before we move them to the final WAL directory.
 log "Stopping pg_receivewal..."
 if kill -0 "$PG_RECEIVEWAL_PID" 2>/dev/null; then
-    kill -TERM "$PG_RECEIVEWAL_PID" 2>/dev/null
-    wait_and_kill_process "$PG_RECEIVEWAL_PID" "pg_receivewal"
+    # Terminate pg_receivewal watchdog first, because it may be waiting for pg_receivewal to exit.
     kill -TERM "$PG_RECEIVEWAL_WATCHDOG_PID" 2>/dev/null
     wait_and_kill_process "$PG_RECEIVEWAL_WATCHDOG_PID" "pg_receivewal watchdog"
+    # Then terminate pg_receivewal
+    kill -TERM "$PG_RECEIVEWAL_PID" 2>/dev/null
+    wait_and_kill_process "$PG_RECEIVEWAL_PID" "pg_receivewal"
 fi
 # We stops pg_receivewal and its watchdog here, so we should not do it on cleanup.
 PG_RECEIVEWAL_PID=""

--- a/pgclone
+++ b/pgclone
@@ -5,7 +5,7 @@
 
 set -euo pipefail
 
-PGCLONE_VERSION="1.0.0"
+PGCLONE_VERSION="1.0.1"
 
 # ==== Default parameters ====
 PGPORT=5432                 # TCP port of the primary Postgres instance (default 5432)
@@ -49,6 +49,7 @@ CLEANUP_DONE=0
 RSYNC_SECRET=""
 RSYNCD_SSH_PID=""
 RSYNCD_WATCHDOG_PID=""
+PSQL_WATCHDOG_PID=""
 RSYNC_LOGFILES=()
 RUN_TMPDIR=""
 
@@ -77,7 +78,6 @@ cleanup() {
         kill "$PG_RECEIVEWAL_WATCHDOG_PID" 2>/dev/null || true
         wait_and_kill_process "$PG_RECEIVEWAL_WATCHDOG_PID" "pg_receivewal watchdog"
     fi
-
     # Stop rsyncd on master via ssh PID
     if [[ -n "${RSYNCD_SSH_PID:-}" ]]; then
         log "Stopping rsyncd (via SSH PID=$RSYNCD_SSH_PID)..."
@@ -89,6 +89,12 @@ cleanup() {
     if [[ -n "${RSYNCD_WATCHDOG_PID:-}" ]]; then
         kill "$RSYNCD_WATCHDOG_PID" 2>/dev/null || true
         wait_and_kill_process "$RSYNCD_WATCHDOG_PID" "rsyncd watchdog"
+    fi
+
+    # Stop psql watchdog
+    if [[ -n "${PSQL_WATCHDOG_PID:-}" ]]; then
+        kill "$PSQL_WATCHDOG_PID" 2>/dev/null || true
+        wait_and_kill_process "$PSQL_WATCHDOG_PID" "psql watchdog"
     fi
 
     # Stop psql
@@ -642,6 +648,19 @@ exec 3>"$PSQL_IN"
 psql_send() { echo "$1" >&3; }
 psql_wait() { grep -m 1 . <"$PSQL_OUT"; }
 
+# Watchdog: terminate main script if psql session exits
+(
+    child_pid=$PSQL_PID
+    main_pid=$PPID
+    while kill -0 "$child_pid" 2>/dev/null && kill -0 "$main_pid" 2>/dev/null; do
+        sleep 1
+    done
+    kill -0 "$main_pid" 2>/dev/null || exit 0
+    log "[watchdog] psql session PID=$child_pid exited"
+    kill -TERM "$main_pid" 2>/dev/null
+) &
+PSQL_WATCHDOG_PID=$!
+
 # ==== PostgreSQL version ====
 psql_send "SHOW server_version_num;"
 ver=$(psql_wait | tr -d '[:space:]')
@@ -686,12 +705,18 @@ fi
 
 # ==== Watchdog for pg_receivewal ====
 (
-    main_pid=$PPID                     # actual PID of the main script
-    while kill -0 "$main_pid" 2>/dev/null; do
+    child_pid=$PG_RECEIVEWAL_PID       # pid of pg_receivewal
+    main_pid=$PPID                     # pid of the main script
+    while kill -0 "$child_pid" 2>/dev/null && kill -0 "$main_pid" 2>/dev/null; do
         sleep 1
     done
-    log "[watchdog] Main process $main_pid died -> terminating pg_receivewal PID=$PG_RECEIVEWAL_PID"
-    watchdog_terminate "$PG_RECEIVEWAL_PID" "pg_receivewal"
+    if ! kill -0 "$main_pid" 2>/dev/null; then
+        log "[watchdog] Main process $main_pid died -> terminating pg_receivewal PID=$child_pid"
+        watchdog_terminate "$child_pid" "pg_receivewal"
+        exit 0
+    fi
+    log "[watchdog] pg_receivewal PID=$child_pid exited"
+    kill -TERM "$main_pid" 2>/dev/null
 ) &
 PG_RECEIVEWAL_WATCHDOG_PID=$!
 
@@ -918,6 +943,9 @@ log "Backup stopped at LSN $STOP_LSN and control files written"
 log "Closing persistent psql session..."
 psql_send '\q'
 wait_and_kill_process "$PSQL_PID" "persistent psql session"
+kill -TERM "$PSQL_WATCHDOG_PID" 2>/dev/null || true
+wait_and_kill_process "$PSQL_WATCHDOG_PID" "psql watchdog"
+PSQL_WATCHDOG_PID=""
 
 # We must be certain the WAL segment that contains STOP_LSN is present on the replica
 # *before* we stop pg_receivewal.  Otherwise the standby will ask for that segment

--- a/tests/01-variants.bats
+++ b/tests/01-variants.bats
@@ -97,9 +97,14 @@ SH
       --parallel 4 \
       --verbose"
   assert_success
-  docker exec -u postgres "$REPLICA" test -L /var/lib/postgresql/data/pg_wal          # symlink
-  docker exec -u postgres "$REPLICA" bash -c "test \"\$(readlink -f /var/lib/postgresql/data/pg_wal)\" = \"$REPLICA_WALDIR_CUSTOM\""
-  docker exec -u postgres "$REPLICA" find "$REPLICA_WALDIR_CUSTOM" -type f -print -quit | grep -q .
+
+  run  docker exec -u postgres "$REPLICA" test -L /var/lib/postgresql/data/pg_wal          # symlink
+  assert_success
+  run docker exec -u postgres "$REPLICA" bash -c "test \"\$(readlink -f /var/lib/postgresql/data/pg_wal)\" = \"$REPLICA_WALDIR_CUSTOM\""
+  assert_success
+  run docker exec -u postgres "$REPLICA" find "$REPLICA_WALDIR_CUSTOM" -type f -print -quit
+  assert_success
+  [[ -n "$output" ]]
 }
 
 #
@@ -128,7 +133,8 @@ SH
       --verbose"
   assert_success
   # directory exists but must be empty
-  docker exec -u postgres "$REPLICA" bash -c '[[ $(find /tmp/my_temp_wal -mindepth 1 | wc -l) -eq 0 ]]'
+  run docker exec -u postgres "$REPLICA" bash -c '[[ $(find /tmp/my_temp_wal -mindepth 1 | wc -l) -eq 0 ]]'
+  assert_success
 }
 
 #

--- a/tests/02-errors.bats
+++ b/tests/02-errors.bats
@@ -265,9 +265,9 @@ EOF
 }
 
 # ------------------------------------------------------------------------------
-# B-10 – pg_receivewal watchdog aborts on streaming stop
+# B-10 – pg_receivewal failure
 # ------------------------------------------------------------------------------
-@test "pg_receivewal watchdog aborts on streaming stop" {
+@test "pg_receivewal failure" {
   start_primary 15; start_replica 15
 
   docker exec -u postgres "$REPLICA" bash -c '
@@ -293,9 +293,8 @@ EOF
     exit 1
   '
 
-  PGW_PID=$(docker exec "$REPLICA" pgrep -f '^pg_receivewal' | head -n1)
+  PGW_PID=$(docker exec "$REPLICA" pgrep -f 'pg_receivewal' | head -n1)
   docker exec "$REPLICA" kill -9 "$PGW_PID"
-  docker exec "$REPLICA" touch /tmp/continue
 
   docker exec -u postgres "$REPLICA" bash -c '
     for i in {1..30}; do
@@ -315,9 +314,9 @@ EOF
 }
 
 # ------------------------------------------------------------------------------
-# B-11 – psql watchdog aborts on session exit
+# B-11 – psql failure
 # ------------------------------------------------------------------------------
-@test "psql watchdog aborts on session exit" {
+@test "psql failure" {
   start_primary 15; start_replica 15
 
   docker exec -u postgres "$REPLICA" bash -c '
@@ -345,7 +344,6 @@ EOF
 
   PSQL_PID=$(docker exec "$REPLICA" pgrep -f "psql .*ON_ERROR_STOP=1" | head -n1)
   docker exec "$REPLICA" kill -9 "$PSQL_PID"
-  docker exec "$REPLICA" touch /tmp/continue
 
   docker exec -u postgres "$REPLICA" bash -c '
     for i in {1..30}; do

--- a/tests/02-errors.bats
+++ b/tests/02-errors.bats
@@ -263,3 +263,103 @@ EOF
 
   check_clean
 }
+
+# ------------------------------------------------------------------------------
+# B-10 – pg_receivewal watchdog aborts on streaming stop
+# ------------------------------------------------------------------------------
+@test "pg_receivewal watchdog aborts on streaming stop" {
+  start_primary 15; start_replica 15
+
+  docker exec -u postgres "$REPLICA" bash -c '
+  export PGPASSWORD=postgres
+  sed "/^# TEST_stop_point_1/a echo \$\$ > /tmp/pgclone.pid; while [ ! -f /tmp/continue ]; do sleep 1; done" /usr/bin/pgclone > /tmp/pgclone.debug &&
+  chmod +x /tmp/pgclone.debug &&
+  /tmp/pgclone.debug \
+    --pghost pg-primary \
+    --pguser postgres \
+    --primary-pgdata /var/lib/postgresql/data \
+    --replica-pgdata /var/lib/postgresql/data \
+    --ssh-key /tmp/id_rsa --ssh-user postgres \
+    --insecure-ssh \
+    --verbose > /tmp/pgclone.log 2>&1; echo $? > /tmp/exit_code
+  ' &
+
+  docker exec -u postgres "$REPLICA" bash -c '
+    for i in {1..30}; do
+      [ -f /tmp/pgclone.pid ] && exit 0
+      sleep 1
+    done
+    echo "pgclone.pid not found" >&2
+    exit 1
+  '
+
+  PGW_PID=$(docker exec "$REPLICA" pgrep -f '^pg_receivewal' | head -n1)
+  docker exec "$REPLICA" kill -9 "$PGW_PID"
+  docker exec "$REPLICA" touch /tmp/continue
+
+  docker exec -u postgres "$REPLICA" bash -c '
+    for i in {1..30}; do
+      [ -f /tmp/exit_code ] && exit 0
+      sleep 1
+    done
+    cat /tmp/pgclone.log
+    echo "pgclone did not exit" >&2
+    exit 1
+  '
+
+  run docker exec -u postgres "$REPLICA" cat /tmp/exit_code
+  [ "$status" -eq 0 ]
+  [ "$output" -ne 0 ]
+
+  check_clean
+}
+
+# ------------------------------------------------------------------------------
+# B-11 – psql watchdog aborts on session exit
+# ------------------------------------------------------------------------------
+@test "psql watchdog aborts on session exit" {
+  start_primary 15; start_replica 15
+
+  docker exec -u postgres "$REPLICA" bash -c '
+  export PGPASSWORD=postgres
+  sed "/^# TEST_stop_point_1/a echo \$\$ > /tmp/pgclone.pid; while [ ! -f /tmp/continue ]; do sleep 1; done" /usr/bin/pgclone > /tmp/pgclone.debug &&
+  chmod +x /tmp/pgclone.debug &&
+  /tmp/pgclone.debug \
+    --pghost pg-primary \
+    --pguser postgres \
+    --primary-pgdata /var/lib/postgresql/data \
+    --replica-pgdata /var/lib/postgresql/data \
+    --ssh-key /tmp/id_rsa --ssh-user postgres \
+    --insecure-ssh \
+    --verbose > /tmp/pgclone.log 2>&1; echo $? > /tmp/exit_code
+  ' &
+
+  docker exec -u postgres "$REPLICA" bash -c '
+    for i in {1..30}; do
+      [ -f /tmp/pgclone.pid ] && exit 0
+      sleep 1
+    done
+    echo "pgclone.pid not found" >&2
+    exit 1
+  '
+
+  PSQL_PID=$(docker exec "$REPLICA" pgrep -f "psql .*ON_ERROR_STOP=1" | head -n1)
+  docker exec "$REPLICA" kill -9 "$PSQL_PID"
+  docker exec "$REPLICA" touch /tmp/continue
+
+  docker exec -u postgres "$REPLICA" bash -c '
+    for i in {1..30}; do
+      [ -f /tmp/exit_code ] && exit 0
+      sleep 1
+    done
+    cat /tmp/pgclone.log
+    echo "pgclone did not exit" >&2
+    exit 1
+  '
+
+  run docker exec -u postgres "$REPLICA" cat /tmp/exit_code
+  [ "$status" -eq 0 ]
+  [ "$output" -ne 0 ]
+
+  check_clean
+}

--- a/tests/03-concurrency.bats
+++ b/tests/03-concurrency.bats
@@ -64,6 +64,8 @@ teardown() { stop_test_env; network_rm; }
   wait
 
   # basic artefact check
-  docker exec -u postgres "$REPLICA" test -f /var/lib/postgresql/replica1/backup_label
-  docker exec -u postgres "$REPLICA" test -f /var/lib/postgresql/replica2/backup_label
+  run docker exec -u postgres "$REPLICA" test -f /var/lib/postgresql/replica1/backup_label
+  assert_success
+  run docker exec -u postgres "$REPLICA" test -f /var/lib/postgresql/replica2/backup_label
+  assert_success
 }

--- a/tests/06-corners.bats
+++ b/tests/06-corners.bats
@@ -42,14 +42,17 @@ teardown() { stop_test_env; network_rm; }
         --insecure-ssh \
         --verbose"
   assert_success
-  docker exec -u postgres "$REPLICA" test -f /var/lib/postgresql/data/backup_label
-  docker exec -u postgres "$REPLICA" test -f /var/lib/postgresql/data/PG_VERSION
+  run docker exec -u postgres "$REPLICA" test -f /var/lib/postgresql/data/backup_label
+  assert_success
+  run docker exec -u postgres "$REPLICA" test -f /var/lib/postgresql/data/PG_VERSION
+  assert_success
 }
 
 @test "replica_waldir == subdir of pgdata (default)" {
   start_primary 15; start_replica 15
   run_pgclone
-  docker exec -u postgres "$REPLICA" test ! -L /var/lib/postgresql/data/pg_wal   # should be a dir, not symlink
+  run docker exec -u postgres "$REPLICA" test ! -L /var/lib/postgresql/data/pg_wal   # should be a dir, not symlink
+  assert_success
 }
 
 @test "garbage in TEMP_WALDIR" {
@@ -57,10 +60,11 @@ teardown() { stop_test_env; network_rm; }
   # inject dummy partial
   docker exec -u postgres "$REPLICA" bash -c "mkdir -p /tmp/pg_wal && touch /tmp/pg_wal/000000010000000000007777"
   run_pgclone
-  docker exec -u postgres "$REPLICA" bash -c '
+  run docker exec -u postgres "$REPLICA" bash -c '
     if [ -f /var/lib/postgresql/data/pg_wal/000000010000000000007777 ]; then \
        echo "file /var/lib/postgresql/data/pg_wal/000000010000000000007777 exists"; \
        exit 1; \
     fi
   '
+  assert_success
 }

--- a/tests/common.sh
+++ b/tests/common.sh
@@ -23,7 +23,7 @@ network_up() {
 }
 
 network_rm() {
-  docker network inspect "$NETWORK" &>/dev/null && docker network rm "$NETWORK"
+  docker network rm -f "$NETWORK"
 }
 
 start_primary() {
@@ -105,7 +105,7 @@ start_pg_on_replica() {
 }
 
 stop_test_env() {
-  docker rm -f --volumes "${_TEST_CONTAINERS[@]}" &>/dev/null || true
+  docker rm -f --volumes "${_TEST_CONTAINERS[@]}"
   _TEST_CONTAINERS=()
 }
 


### PR DESCRIPTION
## Summary
- unify watchdog behavior to terminate main process when pg_receivewal or psql exit
- track PID for the new psql watchdog and stop it during cleanup
- add tests for pg_receivewal and psql watchdog aborts
- remove edits to abort tests
- Switch Bats tests to `run`/`assert_success` pattern for clearer output
  and proper exit-status checking
- Add retry loop when waiting for replica to start streaming, reducing
  flakiness of happy-path scenario
- Strengthen variant tests: explicit assertions, output checks
- Rename two error-handling cases for better readability
- Force-remove Docker network (`docker network rm -f`) and containers
  without silencing errors to surface real failures
- Miscellaneous clean-ups: shorter pg_receivewal/psql grep, safer WAL dir
  checks, minor style fixes
- Create per-run PID file and track main process PID
- Refactor traps: distinct handlers for EXIT, INT, TERM, ERR with reason
  passed to unified cleanup()
- Improve cleanup logic: consistent exit-code handling, detailed logging
- Strengthen watchdogs:
  • psql_watchdog now terminates psql if main process dies and vice-versa
  • pg_receivewal watchdog termination moved earlier for reliability
- Expose new variables (PIDFILE, PGCLONE_MAIN_PID) for external tooling
- Minor code tidy-ups and log message improvements
- Bump PGCLONE_VERSION to 1.1.0