### PR TITLE
Progress locale fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 
 - **Physical replication only** (PostgreSQL 15+)
 - Optional temporary replication slot may be created for `pg_receivewal` (`--slot` flag)
-- **Parallel database sync via rsync+rsyncd** (default workers = *CPU cores × 2*)
+- **Parallel database sync via rsync+rsyncd** (default workers = *CPU cores*)
 - **Paranoid mode** with full checksum verification during copy (`--paranoid`)
 - **Unified progress indicator** – dynamic TTY bar or plain periodic lines for logs, plus aggregated rsync statistics
 - Streaming WAL with `pg_receivewal`
@@ -62,7 +62,7 @@ export PGDATABASE=dbname
     # --insecure-ssh \  # uncomment to skip host-key check (NOT recommended) \
     --ssh-key /path/to/id_rsa \
     --ssh-user root \
-    # --parallel 8  \   # optional override; default = CPU*2
+    # --parallel 8  \   # optional override; default = CPU
     --verbose
 ```
 
@@ -73,7 +73,7 @@ export PGDATABASE=dbname
 - `--replica-pgdata`   — path to PGDATA on the replica (optional, defaults to value of `--primary-pgdata`)
 - `--ssh-key`          — private SSH key (optional; auto-detected from `~/.ssh/id_*` or SSH agent)
 - `--ssh-user`         — SSH user
-- `--parallel`         — number of parallel rsync jobs (default: *CPU cores × 2*)
+- `--parallel`         — number of parallel rsync jobs (default: *CPU cores*)
 - `--paranoid`         — enable checksum verification for every file (`rsync --checksum`). Slower but safest.
 - `--temp-waldir`      — temporary directory for storing WAL files streamed by `pg_receivewal` during the clone (optional; default: system temp dir). If the directory is auto-created by **pgclone**, it will be removed completely on exit; otherwise only its contents are cleaned up.
 - `--drop-existing`    — **dangerous**: remove any data found in the target `--replica-pgdata` and its `pg_wal` directory before starting the clone.

--- a/pgclone
+++ b/pgclone
@@ -543,24 +543,43 @@ parallel_rsync_module() {
     # Try to get precise amount using a dry-run.  Any failure will silently
     # fall back to the estimate above.
     if (( total_bytes > 0 )); then
-        local dry_log dry_bytes
+        local dry_log dry_bytes file_paths
         dry_log=$(TMPDIR="$RUN_TMPDIR" mktemp -t pgclone_dry_${module}.XXXXXX)
+        file_paths=$(TMPDIR="$RUN_TMPDIR" mktemp -t pgclone_paths_${module}.XXXXXX)
+        awk -F'\t' '{print $2}' "$file_raw" > "$file_paths"
+
+        # First attempt: count sizes of files that will be transferred using %l format.
         if rsync -a --dry-run --relative --inplace \
               ${RSYNC_CHECKSUM_FLAG} \
               --exclude 'pgsql_tmp*' \
               --exclude 'pg_internal.init' \
-              --out-format="" --stats \
-              --files-from="$file_raw" \
+              --out-format="%l" \
+              --files-from="$file_paths" \
               --password-file="$RSYNC_SECRET_FILE" \
               "rsync://replica@$PGHOST:$RSYNC_PORT/$module/" "$dst/" \
               >"$dry_log" 2>/dev/null; then
-            dry_bytes=$(awk -F: '/Total transferred file size:/ {print $2}' "$dry_log" | awk '{print $1}')
-            dry_bytes=$(bytes_from_str "$dry_bytes")
-            if [[ -n "$dry_bytes" && "$dry_bytes" =~ ^[0-9]+$ ]]; then
-                total_bytes=$dry_bytes
-            fi
+               dry_bytes=$(awk '/^[0-9]+$/{s+=$1} END{print s}' "$dry_log")
         fi
-        rm -f "$dry_log"
+ 
+        # Fallback: parse --stats output if first method produced zero/empty.
+        if [[ -z "$dry_bytes" || ! "$dry_bytes" =~ ^[0-9]+$ || "$dry_bytes" -eq 0 ]]; then
+            rsync -a --dry-run --relative --inplace \
+                  ${RSYNC_CHECKSUM_FLAG} \
+                  --exclude 'pgsql_tmp*' \
+                  --exclude 'pg_internal.init' \
+                  --out-format="" --stats \
+                  --files-from="$file_paths" \
+                  --password-file="$RSYNC_SECRET_FILE" \
+                  "rsync://replica@$PGHOST:$RSYNC_PORT/$module/" "$dst/" \
+                  >"$dry_log" 2>&1
+            dry_bytes_line=$(awk -F: '/Total transferred file size:/ {print $2}' "$dry_log" | awk '{print $1; exit}' | tr -d '.')
+            dry_bytes=$(bytes_from_str "$dry_bytes_line")
+        fi
+ 
+        if [[ -n "$dry_bytes" && "$dry_bytes" =~ ^[0-9]+$ && "$dry_bytes" -gt 0 ]]; then
+            total_bytes=$dry_bytes
+        fi
+        rm -f "$dry_log" "$file_paths"
     fi
 
     if (( total_bytes == 0 )); then

--- a/pgclone
+++ b/pgclone
@@ -544,8 +544,8 @@ parallel_rsync_module() {
     # fall back to the estimate above.
     if (( total_bytes > 0 )); then
         local dry_log dry_bytes file_paths
-        dry_log=$(TMPDIR="$RUN_TMPDIR" mktemp -t pgclone_dry_${module}.XXXXXX)
-        file_paths=$(TMPDIR="$RUN_TMPDIR" mktemp -t pgclone_paths_${module}.XXXXXX)
+        dry_log=$(TMPDIR="$RUN_TMPDIR" mktemp -t pgclone_dry_"${module}".XXXXXX)
+        file_paths=$(TMPDIR="$RUN_TMPDIR" mktemp -t pgclone_paths_"${module}".XXXXXX)
         awk -F'\t' '{print $2}' "$file_raw" > "$file_paths"
 
         # First attempt: count sizes of files that will be transferred using %l format.

--- a/pgclone
+++ b/pgclone
@@ -5,7 +5,7 @@
 
 set -euo pipefail
 
-PGCLONE_VERSION="1.3.1"
+PGCLONE_VERSION="1.3.2"
 
 # ==== Default parameters ====
 PGPORT=5432                 # TCP port of the primary Postgres instance (default 5432)
@@ -346,11 +346,15 @@ format_bytes() {
 bytes_from_str() {
     # Convert "3.36T", "357M", "1,024" → bytes (integer). Supports K/M/G/T/P.
     local s="${1,,}"            # to lowercase
-    s="${s//,/}"                # remove thousands separators
+    # Normalize the string:
     s="${s// bytes/}"
     s="${s//byte/}"
-    s="${s// /}"                # remove spaces
-    s="${s//i/}"                # drop 'i' in KiB/MiB units
+    s="${s//[[:space:]]/}"      # remove whitespace / NBSP
+    s="${s//i/}"                # drop 'i' in KiB/MiB units (KiB -> KB)
+
+    # Convert decimal comma to dot for locale-independent parsing
+    s="${s//,/.}"
+
     local unit="${s: -1}"
     local num
     if [[ $unit =~ [KkMmGgTtPp] ]]; then
@@ -359,8 +363,16 @@ bytes_from_str() {
         unit=""
         num="$s"
     fi
-    num="${num//,/}"
-    num="${num//,/}"
+
+    # Handle thousands separators:
+    #  – If the number now has a single dot and exactly 3 digits after it, treat dot as thousands separator.
+    #  – If it has more than one dot, assume all are thousands separators.
+    if [[ "$num" =~ ^[0-9]+\.[0-9]{3}$ ]]; then
+        num="${num//./}"
+    elif [[ $(grep -o '\.' <<< "$num" | wc -l) -gt 1 ]]; then
+        num="${num//./}"
+    fi
+
     local mul=1
 
     # Return 0 if number part empty (unexpected input)
@@ -376,13 +388,26 @@ bytes_from_str() {
     awk -v n="${num//,/.}" -v m="$mul" 'BEGIN{printf "%.0f", n*m}'
 }
 
+# int_from_stats: convert a string containing an integer with optional spaces or
+# comma thousands separators into a pure integer. Example: "12,345" -> 12345,
+# "1 234" (NBSP) -> 1234.  Returns 0 if the input is empty.
+int_from_stats() {
+    local s="$1"
+    # Remove any whitespace (including non-breaking) and commas used as thousand separators
+    s="${s//[[:space:]]/}"
+    s="${s//,/}"
+    [[ -z "$s" ]] && s=0
+    echo "$s"
+}
+
 aggregate_rsync_stats() {
-    # Usage: aggregate_rsync_stats logfile1 logfile2 ...
+    # Usage: aggregate_rsync_stats total_transferred logfile1 logfile2 ...
+    local transferred_override="$1"; shift
     local logfiles=("$@")
     local line val
     local num_files=0 created_files=0 deleted_files=0 reg_transferred=0
     local total_file_size=0 total_transferred_size=0 literal_data=0 matched_data=0
-    local file_list_size=0 file_list_gen_time=0 file_list_tx_time=0
+    local file_list_size=0 file_list_gen_time=0
     local bytes_sent=0 bytes_received=0
 
     # (debug logs removed)
@@ -390,20 +415,20 @@ aggregate_rsync_stats() {
         while IFS= read -r line; do
             case "$line" in
                 "Number of files:"*)
-                    val=$(echo "$line" | grep -oE '[0-9]+' | head -1)
-                    [[ -z "$val" ]] && val=0
+                    val=$(echo "$line" | awk -F: '{print $2}' | awk '{print $1}')
+                    val=$(int_from_stats "$val")
                     (( num_files += val )) ;;
                 "Number of created files:"*)
-                    val=$(echo "$line" | grep -oE '[0-9]+' | head -1)
-                    [[ -z "$val" ]] && val=0
+                    val=$(echo "$line" | awk -F: '{print $2}' | awk '{print $1}')
+                    val=$(int_from_stats "$val")
                     (( created_files += val )) ;;
                 "Number of deleted files:"*)
-                    val=$(echo "$line" | grep -oE '[0-9]+' | head -1)
-                    [[ -z "$val" ]] && val=0
+                    val=$(echo "$line" | awk -F: '{print $2}' | awk '{print $1}')
+                    val=$(int_from_stats "$val")
                     (( deleted_files += val )) ;;
                 "Number of regular files transferred:"*)
-                    val=$(echo "$line" | grep -oE '[0-9]+' | head -1)
-                    [[ -z "$val" ]] && val=0
+                    val=$(echo "$line" | awk -F: '{print $2}' | awk '{print $1}')
+                    val=$(int_from_stats "$val")
                     (( reg_transferred += val )) ;;
                 "Total file size:"*)
                     val=$(echo "$line" | awk -F: '{print $2}' | awk '{print $1}')
@@ -422,30 +447,32 @@ aggregate_rsync_stats() {
                     file_list_size=$(( file_list_size + $(bytes_from_str "$val") )) ;;
                 "File list generation time:"*)
                     val=$(echo "$line" | awk -F: '{print $2}' | awk '{print $1}')
-                    file_list_gen_time=$(awk -v a="$file_list_gen_time" -v b="${val//,/}" 'BEGIN{printf "%.3f", a+b}') ;;
-                "File list transfer time:"*)
-                    val=$(echo "$line" | awk -F: '{print $2}' | awk '{print $1}')
-                    file_list_tx_time=$(awk -v a="$file_list_tx_time" -v b="${val//,/}" 'BEGIN{printf "%.3f", a+b}') ;;
+                    val_dec=${val//,/.}
+                    file_list_gen_time=$(awk -v a="$file_list_gen_time" -v b="$val_dec" 'BEGIN{if(b>a)printf "%.3f", b; else printf "%.3f", a}') ;;
+                # skip "File list transfer time:" no need to track it
+                "File list transfer time:"*) ;;
                 "Total bytes sent:"*)
                     val=$(echo "$line" | awk -F: '{print $2}' | awk '{print $1}')
                     bytes_sent=$(( bytes_sent + $(bytes_from_str "$val") )) ;;
-                "Total bytes received:"*)
-                    val=$(echo "$line" | awk -F: '{print $2}' | awk '{print $1}')
-                    bytes_received=$(( bytes_received + $(bytes_from_str "$val") )) ;;
+                # Skip "Total bytes received:" – we rely on precise counter from progress aggregator
+                "Total bytes received:"*) ;;
                 "sent "*)
-                    # final summary line
+                    # final summary line – use only "sent" part; ignore "received" as it's per-worker duplicate
                     sent=$(echo "$line" | awk '{print $2}')
-                    recv=$(echo "$line" | awk '{print $5}')
-                    bytes_sent=$(( bytes_sent + $(bytes_from_str "$sent") ))
-                    bytes_received=$(( bytes_received + $(bytes_from_str "$recv") )) ;;
+                    bytes_sent=$(( bytes_sent + $(bytes_from_str "$sent") )) ;;
             esac
         done < "$lf" || true
     done
 
-    local total_bytes=$(( bytes_sent + bytes_received ))
+    # If progress aggregator provided precise value, override
+    if [[ -n "$transferred_override" && "$transferred_override" =~ ^[0-9]+$ && "$transferred_override" -gt 0 ]]; then
+        bytes_received="$transferred_override"
+    fi
+
     local elapsed=$(( $(date +%s) - AGGR_START_EPOCH ))
     (( elapsed == 0 )) && elapsed=1
-    local speed=$(( total_bytes / elapsed ))
+    local speed_up=$(( bytes_sent / elapsed ))
+    local speed_down=$(( bytes_received / elapsed ))
 
     # ---------- output ----------
     echo
@@ -459,16 +486,14 @@ aggregate_rsync_stats() {
     printf "Matched data: %s\n" "$(format_bytes "$matched_data")"
     printf "File list size: %s\n" "$(format_bytes "$file_list_size")"
     printf "File list generation time: %s seconds\n" "$file_list_gen_time"
-    printf "File list transfer time: %s seconds\n" "$file_list_tx_time"
     printf "Total bytes sent: %s\n" "$(format_bytes "$bytes_sent")"
     printf "Total bytes received: %s\n" "$(format_bytes "$bytes_received")"
     echo
-    printf "sent %s  received %s  %s/sec\n" \
+    printf "sent %s (%s/sec) received %s (%s/sec)\n" \
         "$(format_bytes "$bytes_sent")" \
+        "$(format_bytes "$speed_up")" \
         "$(format_bytes "$bytes_received")" \
-        "$(format_bytes "$speed")"
-
-    # (debug summary removed)
+        "$(format_bytes "$speed_down")"
 }
 
 # $1 = rsync-module, $2 = dst
@@ -528,6 +553,10 @@ parallel_rsync_module() {
         while read -r d; do mkdir -p "$dst/$d"; done
 
     # ---- total bytes for progress ----
+    # Temp file for passing final transferred total from aggregator to parent
+    local progress_total_file
+    progress_total_file=$(TMPDIR="$RUN_TMPDIR" mktemp -t pgclone_transfer_total_"${module}".XXXXXX)
+
     # Determine how many bytes actually need to be transferred.  We perform
     # a quick rsync dry-run that computes the exact "Total transferred file size"
     # for this module.  This prevents the progress bar from starting at 0 %
@@ -623,7 +652,7 @@ parallel_rsync_module() {
                 local percent=$(( transferred * 100 / total_bytes ))
                 (( percent > 100 )) && percent=100
                 local filled=$(( percent * bar_width / 100 ))
-                printf '\r[' >&2
+                printf '\r\033[K[' >&2
                 if (( filled > 0 )); then printf '#%.0s' $(seq 1 $filled) >&2; fi
                 local remaining=$(( bar_width - filled ))
                 if (( remaining > 0 )); then printf -- '-%.0s' $(seq 1 $remaining) >&2; fi
@@ -648,13 +677,16 @@ parallel_rsync_module() {
         (( duration==0 )) && duration=1
         local speed_final=$(( total_bytes / duration ))
         if (( show_bar )); then
-            printf "\r[" >&2; printf '#%.0s' $(seq 1 $bar_width) >&2; printf "] 100 %% (%s / %s)\n" \
+            printf "\r\033[K[" >&2; printf '#%.0s' $(seq 1 $bar_width) >&2; printf "] 100 %% (%s / %s)\n" \
                 "$(format_bytes "$total_bytes")" "$(format_bytes "$total_bytes")" >&2
         elif (( show_plain )); then
             printf "[%s] 100 %%  (%s / %s, %s/s)\n" \
                 "$(date '+%F %T')" "$(format_bytes "$total_bytes")" "$(format_bytes "$total_bytes")" \
                 "$(format_bytes "$speed_final")" >&2
         fi
+
+        # Persist the precise transferred amount for parent process
+        echo "$transferred" > "$progress_total_file"
     ) &
     AGGR_PID=$!
 
@@ -709,8 +741,15 @@ parallel_rsync_module() {
         fi
     fi
 
+    # Read precise transferred total recorded by aggregator
+    local progress_total=0
+    if [[ -f "$progress_total_file" ]]; then
+        progress_total=$(cat "$progress_total_file" 2>/dev/null || echo 0)
+        rm -f "$progress_total_file"
+    fi
+
     # Aggregate and print rsync statistics
-    aggregate_rsync_stats "${RSYNC_LOGFILES[@]}"
+    aggregate_rsync_stats "$progress_total" "${RSYNC_LOGFILES[@]}"
 
     # Cleanup temporary files
     for f in "${RSYNC_LOGFILES[@]}"; do rm -f "$f"; done

--- a/pgclone
+++ b/pgclone
@@ -904,6 +904,9 @@ fi
 [[ "$PGPORT"    =~ ^[0-9]+$ ]] || fatal "Invalid port"
 [[ "$PARALLEL"  =~ ^[0-9]+$ ]] || fatal "Invalid parallel"
 
+# Informative log about parallelism
+log "Using $PARALLEL parallel rsync worker(s)"
+
 # ---- TEMP_WALDIR handling ----
 if [[ -z "${TEMP_WALDIR:-}" ]]; then
     TEMP_WALDIR=$(TMPDIR="$RUN_TMPDIR" mktemp -d -t pgclone_temp.XXXXXX)

--- a/pgclone
+++ b/pgclone
@@ -5,7 +5,7 @@
 
 set -euo pipefail
 
-PGCLONE_VERSION="1.3.0"
+PGCLONE_VERSION="1.3.1"
 
 # ==== Default parameters ====
 PGPORT=5432                 # TCP port of the primary Postgres instance (default 5432)
@@ -458,8 +458,8 @@ aggregate_rsync_stats() {
     printf "Literal data: %s\n" "$(format_bytes "$literal_data")"
     printf "Matched data: %s\n" "$(format_bytes "$matched_data")"
     printf "File list size: %s\n" "$(format_bytes "$file_list_size")"
-    printf "File list generation time: %.3f seconds\n" "$file_list_gen_time"
-    printf "File list transfer time: %.3f seconds\n" "$file_list_tx_time"
+    printf "File list generation time: %s seconds\n" "$file_list_gen_time"
+    printf "File list transfer time: %s seconds\n" "$file_list_tx_time"
     printf "Total bytes sent: %s\n" "$(format_bytes "$bytes_sent")"
     printf "Total bytes received: %s\n" "$(format_bytes "$bytes_received")"
     echo
@@ -636,7 +636,7 @@ parallel_rsync_module() {
                   --files-from="${parts[$idx]}" \
                   --password-file="$RSYNC_SECRET_FILE" \
                   "rsync://replica@$PGHOST:$RSYNC_PORT/$module/" "$dst/" \
-                  > >(awk -v p="$progress_pipe" -v l="$logfile" '{ if ($0 ~ /^[0-9]+$/) print > p; print >> l }') \
+                  > >(awk -v p="$progress_pipe" -v l="$logfile" '{ if ($0 ~ /^[0-9]+$/) { print > p; fflush(p) } ; print >> l;  }') \
                   2>>"$logfile"
         ) &
         pids+=($!)

--- a/pgclone
+++ b/pgclone
@@ -13,7 +13,7 @@ REPLICA_WALDIR=""           # Destination pg_wal directory on the replica;
                             # empty ⇒ use "$REPLICA_PGDATA/pg_wal"
 TEMP_WALDIR=""              # Temporary directory where pg_receivewal stores incoming WAL;
                             # empty ⇒ auto-create under /tmp
-PARALLEL=$(( $( (getconf _NPROCESSORS_ONLN 2>/dev/null || nproc 2>/dev/null || echo 1) ) * 2 ))  # Number of simultaneous rsync workers (CPU cores x2)
+PARALLEL=$(( $( (getconf _NPROCESSORS_ONLN 2>/dev/null || nproc 2>/dev/null || echo 1) ) * 1 ))  # Number of simultaneous rsync workers (CPU cores)
 PARANOID=0                  # 1 = enable rsync --checksum for all copy operations
 TEMP_WALDIR_CREATED=0       # 1 = TEMP_WALDIR was auto-created and should be removed entirely
 VERBOSE=0                   # 1 = print detailed progress/debug logs, 0 = quiet
@@ -687,7 +687,7 @@ Usage: pgclone [OPTIONS]
   --ssh-key            SSH private key file (optional, auto-detected if omitted)
   --ssh-user           SSH user (login on primary host) (required)
   --temp-waldir        Temporary WAL directory (optional, default: system tmp)
-  --parallel           Number of parallel rsync jobs (optional, default: CPU*2)
+  --parallel           Number of parallel rsync jobs (optional, default: CPU)
   --paranoid           Enable checksum verification (rsync --checksum, VERY SLOW) (optional, default: disabled)
   --drop-existing      Remove existing data in replica pgdata and pg_wal before cloning (optional, default: disabled)
   --debug              Enable bash trace (set -x) for troubleshooting (optional, default: disabled)

--- a/pgclone
+++ b/pgclone
@@ -528,9 +528,40 @@ parallel_rsync_module() {
         while read -r d; do mkdir -p "$dst/$d"; done
 
     # ---- total bytes for progress ----
+    # Determine how many bytes actually need to be transferred.  We perform
+    # a quick rsync dry-run that computes the exact "Total transferred file size"
+    # for this module.  This prevents the progress bar from starting at 0 %
+    # and then jumping straight to 100 % when most of the data is already
+    # present locally.
+
     local total_bytes
+
+    # Default fallback – whole remote size (may over-estimate if many files are unchanged)
     total_bytes=$(awk -F'\t' '{s+=$1} END{print s}' "$file_raw")
     [[ -z "$total_bytes" ]] && total_bytes=0
+
+    # Try to get precise amount using a dry-run.  Any failure will silently
+    # fall back to the estimate above.
+    if (( total_bytes > 0 )); then
+        local dry_log dry_bytes
+        dry_log=$(TMPDIR="$RUN_TMPDIR" mktemp -t pgclone_dry_${module}.XXXXXX)
+        if rsync -a --dry-run --relative --inplace \
+              ${RSYNC_CHECKSUM_FLAG} \
+              --exclude 'pgsql_tmp*' \
+              --exclude 'pg_internal.init' \
+              --out-format="" --stats \
+              --files-from="$file_raw" \
+              --password-file="$RSYNC_SECRET_FILE" \
+              "rsync://replica@$PGHOST:$RSYNC_PORT/$module/" "$dst/" \
+              >"$dry_log" 2>/dev/null; then
+            dry_bytes=$(awk -F: '/Total transferred file size:/ {print $2}' "$dry_log" | awk '{print $1}')
+            dry_bytes=$(bytes_from_str "$dry_bytes")
+            if [[ -n "$dry_bytes" && "$dry_bytes" =~ ^[0-9]+$ ]]; then
+                total_bytes=$dry_bytes
+            fi
+        fi
+        rm -f "$dry_log"
+    fi
 
     if (( total_bytes == 0 )); then
         log "[rsync] Module $module: nothing to transfer (empty file list)"

--- a/tests/02-errors.bats
+++ b/tests/02-errors.bats
@@ -202,7 +202,7 @@ docker exec -u postgres "$REPLICA" bash -c '
 #!/usr/bin/env bash
 # Only stub the parallel worker calls (--relative --inplace)
 # Everything else (initial sync, --list-only) goes to real rsync
-if [[ "\$*" == *"--relative"* && "\$*" == *"--inplace"* ]]; then
+if [[ "\$*" == *"--relative"* && "\$*" == *"--inplace"* && "\$*" != *"--dry-run"* ]]; then
   while true; do echo test; sleep 1; done
 else
   exec /usr/bin/rsync "\$@"

--- a/tests/05-aborts.bats
+++ b/tests/05-aborts.bats
@@ -103,7 +103,7 @@ docker exec -u postgres "$REPLICA" bash -c '
 #!/usr/bin/env bash
 # Only stub the parallel worker calls (--relative --inplace)
 # Everything else (initial sync, --list-only) goes to real rsync
-if [[ "\$*" == *"--relative"* && "\$*" == *"--inplace"* ]]; then
+if [[ "\$*" == *"--relative"* && "\$*" == *"--inplace"* && "\$*" != *"--dry-run"* ]]; then
   while true; do echo test; sleep 1; done
 else
   exec /usr/bin/rsync "\$@"


### PR DESCRIPTION
### Summary
This PR improves the progress indicator and rsync statistics accuracy under non-C locales.

### Key changes
* Clear-to-end-of-line escape in progress bar to eliminate residual characters
* Progress aggregator writes precise transferred total; summary uses it instead of per-worker 'received'
* `bytes_from_str` now parses decimal commas and thousand separators
* `int_from_stats` helper fixes counters with separators (Number of files, created, deleted, transferred)
* File list generation/transfer time aggregated via max across workers
* Misc output tweaks (separate up/down speed)

### Motivation
On ru_RU and other locales the summary displayed inflated totals due to comma decimal separator and duplicated per-worker stats. The fixes align summary numbers with the progress bar and real network usage.

### Testing
* Ran `tests/07-progress.bats` – all pass
* Manual clone with ru_RU.UTF-8 locale shows matching figures between progress bar and summary.